### PR TITLE
Unblock edge 4.3.12

### DIFF
--- a/blocked-edges/4.3.12.yaml
+++ b/blocked-edges/4.3.12.yaml
@@ -1,3 +1,0 @@
-to: 4.3.12
-from: .*
-# 4.3.8 - 4.3.12 block updates on mutated SCCs at the intersection of https://bugzilla.redhat.com/show_bug.cgi?id=1821905 https://bugzilla.redhat.com/show_bug.cgi?id=1820231


### PR DESCRIPTION
6 clusters currently failing ( 8%),  8 gone (11%), and 61 successful (80%), out of 76 who attempted the update over 7d