### PR TITLE
Block edge 4.3.12

### DIFF
--- a/blocked-edges/4.3.12.yaml
+++ b/blocked-edges/4.3.12.yaml
@@ -1,3 +1,3 @@
+---
 to: 4.3.12
-from: .*
-# 4.3.8 - 4.3.12 block updates on mutated SCCs at the intersection of https://bugzilla.redhat.com/show_bug.cgi?id=1821905 https://bugzilla.redhat.com/show_bug.cgi?id=1820231
+from: ".*"


### PR DESCRIPTION
2 clusters currently failing (17%),  6 gone (50%), and  4 successful (33%), out of 12 who attempted the update over 7d